### PR TITLE
Downgrades min VSCode requirement to 1.96.2 for Cursor compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
     "name": "f1r3fly-io-rholang",
     "displayName": "Rholang (F1R3FLY.io)",
     "description": "Language support for Rholang.",
-    "version": "0.0.2",
+    "version": "0.0.3",
     "publisher": "F1R3FLY-io",
     "icon": "images/f1r3fly-io-logo.png",
     "repository": {
@@ -10,7 +10,7 @@
         "url": "https://github.com/F1R3FLY-io/rholang-vscode-client"
     },
     "engines": {
-        "vscode": "^1.99.1"
+        "vscode": "^1.96.2"
     },
     "categories": [
         "Programming Languages"
@@ -72,7 +72,7 @@
     },
     "devDependencies": {
         "@types/node": "^22.15.2",
-        "@types/vscode": "^1.99.1",
+        "@types/vscode": "^1.96.2",
         "@vscode/vsce": "^3.3.2",
         "esbuild": "^0.25.3",
         "typescript": "^5.8.3"

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -47,7 +47,9 @@ export async function activate(context: vscode.ExtensionContext) {
     if (!!serverPath && await isExecutable(serverPath)) {
         const serverOptions: ServerOptions = {
             command: serverPath,
-            args: [],
+            args: [
+              "--no-color",  // Disable ANSI color escape codes
+            ],
             transport: TransportKind.stdio
         };
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,7 +1,6 @@
 "use strict";
 
 import fs from 'fs';
-
 import * as vscode from "vscode";
 import {
     LanguageClient,
@@ -9,7 +8,6 @@ import {
     ServerOptions,
     TransportKind
 } from 'vscode-languageclient/node';
-
 import which from "which";
 
 let client: LanguageClient;
@@ -48,7 +46,8 @@ export async function activate(context: vscode.ExtensionContext) {
         const serverOptions: ServerOptions = {
             command: serverPath,
             args: [
-              "--no-color",  // Disable ANSI color escape codes
+                "--no-color",  // Disable ANSI color escape codes
+                "--client-process-id", process.pid.toString()
             ],
             transport: TransportKind.stdio
         };


### PR DESCRIPTION
Changes:
- Downgrades min VSCode requirement to 1.96.2 for compatibility with [Cursor](https://www.cursor.com/)
- Disables ANSI color escape sequences in server logs
- Passes VSCode PID to rholang-language-server
- Bumps version to 0.0.3